### PR TITLE
using() now accepts variable length of arguments, instead of 2

### DIFF
--- a/example/example1.php
+++ b/example/example1.php
@@ -2,9 +2,9 @@
 
 include __DIR__ . "/../vendor/autoload.php";
 
-use G\IDisposable;
+use G\DisposableInterface;
 
-class Bar implements IDisposable
+class Bar implements DisposableInterface
 {
     public function hello($name)
     {
@@ -17,7 +17,7 @@ class Bar implements IDisposable
     }
 }
 
-class Foo implements IDisposable
+class Foo implements DisposableInterface
 {
     public function hello($name)
     {
@@ -30,7 +30,7 @@ class Foo implements IDisposable
     }
 }
 
-using([new Bar, new Foo], function (Bar $bar, Foo $foo) {
+using(new Bar, new Foo, function (Bar $bar, Foo $foo) {
         echo $bar->hello("Gonzalo");
         echo $foo->hello("Gonzalo");
     });

--- a/example/example2.php
+++ b/example/example2.php
@@ -2,9 +2,9 @@
 
 include __DIR__ . "/../vendor/autoload.php";
 
-use G\IDisposable;
+use G\DisposableInterface;
 
-class File implements IDisposable
+class File implements DisposableInterface
 {
     private $resource;
 

--- a/example/example3.php
+++ b/example/example3.php
@@ -2,9 +2,9 @@
 
 include __DIR__ . "/../vendor/autoload.php";
 
-use G\IDisposable;
+use G\DisposableInterface;
 
-class Bar implements IDisposable
+class Bar implements DisposableInterface
 {
     public function hello($name)
     {

--- a/src/G/DisposableInterface.php
+++ b/src/G/DisposableInterface.php
@@ -1,8 +1,7 @@
 <?php
-
 namespace G;
 
-interface IDisposable
+interface DisposableInterface
 {
     public function dispose();
 }

--- a/src/G/Functions.php
+++ b/src/G/Functions.php
@@ -18,14 +18,18 @@ function using(/* $input1, $input2, ... $inputN, $callback */)
     if (!is_callable($callback))
         throw new Exception('using() requires the last parameter to be a callable');
 
-    try {
-        call_user_func_array($callback, $params);
-    } catch (Exception $ex) {
-      throw $ex;
-    } finally {
+    $cleanup = function () use ($params) {
         foreach ($params as $p) {
             if ($p instanceof DisposableInterface)
                 $p->dispose();
         }
+    };
+
+    try {
+        call_user_func_array($callback, $params);
+        $cleanup();
+    } catch (Exception $ex) {
+        $cleanup();
+        throw $ex;
     }
 }

--- a/src/G/Functions.php
+++ b/src/G/Functions.php
@@ -1,32 +1,31 @@
 <?php
-
-use G\IDisposable;
+use G\DisposableInterface;
 
 /**
- * @param G\IDisposable|G\IDisposable[] $inputs
+ * @param G\DisposableInterface $input1,...,$inputN
  * @param callable $callback
  * @throws Exception
  */
-function using($inputs, callable $callback=null)
+function using(/* $input1, $input2, ... $inputN, $callback */)
 {
-    if (!is_array($inputs)) {
-        $inputs = [$inputs];
-    }
+    $params = func_get_args();
 
-    $disponser = function($inputs) {
-        foreach ($inputs as $input) {
-            if ($input instanceof IDisposable) {
-                $input->dispose();
-            }
-        }
-    };
+    if (count($params) < 2)
+        throw new Exception('using() requires at least 2 parameters');
+
+    $callback = array_pop($params);
+
+    if (!is_callable($callback))
+        throw new Exception('using() requires the last parameter to be a callable');
 
     try {
-        call_user_func_array($callback, $inputs);
-        $disponser($inputs);
-    } catch (\Exception $e) {
-        $disponser($inputs);
-
-        throw $e;
+        call_user_func_array($callback, $params);
+    } catch (Exception $ex) {
+      throw $ex;
+    } finally {
+        foreach ($params as $p) {
+            if ($p instanceof DisposableInterface)
+                $p->dispose();
+        }
     }
 }

--- a/tests/UsingTest.php
+++ b/tests/UsingTest.php
@@ -73,7 +73,7 @@ class UsingTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($disposeCalled['foo'], 'Foo dispose has been called');
         $this->assertFalse($disposeCalled['bar'], 'Bar dispose has been called');
 
-        using([$foo, $bar], function (Foo $foo, Bar $bar) {
+        using($foo, $bar, function (Foo $foo, Bar $bar) {
                 $foo->hello("Gonzalo");
                 $bar->hello("Gonzalo");
             });
@@ -109,7 +109,7 @@ class UsingTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($disposeCalled['bar'], 'Bar dispose has been called');
 
         try {
-            using([$foo, $bar], function (Foo $foo, Bar $bar) {
+            using($foo, $bar, function (Foo $foo, Bar $bar) {
                     $foo->hello("Gonzalo");
                     $bar->hello("Gonzalo");
                 });

--- a/tests/src/Bar.php
+++ b/tests/src/Bar.php
@@ -1,8 +1,8 @@
 <?php
 
-use G\IDisposable;
+use G\DisposableInterface;
 
-class Bar implements IDisposable
+class Bar implements DisposableInterface
 {
     public function hello($name)
     {

--- a/tests/src/Foo.php
+++ b/tests/src/Foo.php
@@ -1,8 +1,8 @@
 <?php
 
-use G\IDisposable;
+use G\DisposableInterface;
 
-class Foo implements IDisposable
+class Foo implements DisposableInterface
 {
     public function hello($name)
     {


### PR DESCRIPTION
Changed using() so it accepts N arguments, where the last argument needs to be a callable. Arguments 1 to N-1 are all considered input. Minimum number of required arguments are 2. Throws an exception called with incorrect number of arguments, or if no callable callback was provided.

Renamed IDisposable to DisposableInterface (more common practice in PHP).

Updated tests and examples to make use of new syntax.
